### PR TITLE
Add 'name' field to metadata.rb, for Berkshelf compatibility.

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -1,3 +1,4 @@
+name             "authconfig"
 maintainer       "Jesse Campbell"
 maintainer_email "hikeit@gmail.com"
 license          "Apache License"


### PR DESCRIPTION
Berkshelf uses this cookbook from offiste, successfully, without the "name" field set in metadata.rb. However, if testing locally with a local directory of modified cookbooks, it gets confused and fails to locally "update" or "install" the coookbook for Berkshelf feployment.