### PR TITLE
Change sssd service to restart only if sssd is enabled

### DIFF
--- a/CHANNGELOG.md
+++ b/CHANNGELOG.md
@@ -1,0 +1,8 @@
+authconfig Cookbook Changelog
+=============================
+This file is used to list changes made in each version of the authconfig cookbook.
+
+v1.1.13
+-------
+### BUG
+- Avoid sssd start or restart if sssd daemon disabled

--- a/metadata.rb
+++ b/metadata.rb
@@ -3,4 +3,4 @@ maintainer_email "hikeit@gmail.com"
 license          "Apache License"
 description      "Configures authconfig"
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          "1.1.2"
+version          "1.1.3"

--- a/metadata.rb
+++ b/metadata.rb
@@ -1,3 +1,4 @@
+name             "authconfig"
 maintainer       "Jesse Campbell"
 maintainer_email "hikeit@gmail.com"
 license          "Apache License"

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -98,10 +98,8 @@ if node[:platform_version].to_i == 6
 		group "root"
 		notifies :run, "execute[clean_sss_db]", :immediately
 		notifies :run, "execute[restorecon /etc/sssd/sssd.conf]", :immediately
-		# Restart sssd only if actually used
-		if node['authconfig']['ldap]['enable']
-			notifies :restart, "service[sssd]", :immediately
-		elsif node['authconfig']['kerberos']['enable']
+		# Restart sssd only if LDAP actually enables it
+		if node['authconfig']['ldap']['enable']
 			notifies :restart, "service[sssd]", :immediately
 		end
 

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -80,8 +80,8 @@ if node[:platform_version].to_i == 6
 
 	service "sssd" do
 		supports :status => true, :restart => true, :reload => true
-		# Avoid starting or restarting sssd if disabled
-		# Especially needed if kerberos enabled, ldap disabled
+		# Avoid starting or restarting sssd if disabled,
+		# especially when kerberos is enabled, and ldap not
 		restart_command "/sbin/chkconfig sssd | grep -v :on || /sbin/service sssd restart"
 		start_command "/sbin/chkconfig sssd | grep -v :on || /sbin/service sssd restart"
 	end

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -104,7 +104,6 @@ if node[:platform_version].to_i == 6
 		end
 
 		notifies :reload, "ohai[reload]", :immediately
-
 	end
 
 elsif node[:platform_version].to_i == 5

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -82,8 +82,8 @@ if node[:platform_version].to_i == 6
 		supports :status => true, :restart => true, :reload => true
 		# Avoid starting or restarting sssd if disabled,
 		# especially when kerberos is enabled, and ldap not
-		restart_command "/sbin/chkconfig sssd | grep -v :on || /sbin/service sssd restart"
-		start_command "/sbin/chkconfig sssd | grep -v :on || /sbin/service sssd start"
+		restart_command "/sbin/chkconfig sssd --list | grep -v :on || /sbin/service sssd restart"
+		start_command "/sbin/chkconfig sssd --list | grep -v :on || /sbin/service sssd start"
 	end
 
 	execute "clean_sss_db" do

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -83,7 +83,7 @@ if node[:platform_version].to_i == 6
 		# Avoid starting or restarting sssd if disabled,
 		# especially when kerberos is enabled, and ldap not
 		restart_command "/sbin/chkconfig sssd | grep -v :on || /sbin/service sssd restart"
-		start_command "/sbin/chkconfig sssd | grep -v :on || /sbin/service sssd restart"
+		start_command "/sbin/chkconfig sssd | grep -v :on || /sbin/service sssd start"
 	end
 
 	execute "clean_sss_db" do

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -98,8 +98,15 @@ if node[:platform_version].to_i == 6
 		group "root"
 		notifies :run, "execute[clean_sss_db]", :immediately
 		notifies :run, "execute[restorecon /etc/sssd/sssd.conf]", :immediately
-		notifies :restart, "service[sssd]", :immediately
+		# Restart sssd only if actually used
+		if node['authconfig']['ldap]['enable']
+			notifies :restart, "service[sssd]", :immediately
+		elsif node['authconfig']['kerberos']['enable']
+			notifies :restart, "service[sssd]", :immediately
+		end
+
 		notifies :reload, "ohai[reload]", :immediately
+
 	end
 
 elsif node[:platform_version].to_i == 5


### PR DESCRIPTION
Rewrite patch to prevent systems with Kerbers and not LDAP to avoid restarting sssd. sssd is disabled, and left disabled, by the authconfig command in these cases.

This runs /sbin/chkconfig to verify that sssd is enabled. It will need a rewrite for systemd based RHEL 7.