### PR TITLE
Enable sensitive attribute on sssd template.

### DIFF
--- a/Berksfile
+++ b/Berksfile
@@ -1,3 +1,3 @@
-site :opscode
+site "https://supermarket.chef.io"
 
 metadata

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -96,6 +96,7 @@ if node[:platform_version].to_i == 6
 	end
 
 	template "/etc/sssd/sssd.conf" do
+    sensitive true
 		source "sssd.conf.erb"
 		mode 0600
 		owner "root"

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -96,7 +96,7 @@ if node[:platform_version].to_i == 6
 	end
 
 	template "/etc/sssd/sssd.conf" do
-		senstitive true
+		sensitive true
 		source "sssd.conf.erb"
 		mode 0600
 		owner "root"

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -67,7 +67,7 @@ if node['authconfig']['kerberos']['enable']
 	end
 end
 
-if node[:platform_version].to_i == 6
+if [6 , 7].include? node[:platform_version].to_i 
 	if node['authconfig']['ldap']['enable']
 		package 'pam_ldap' do
 			action :install

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -96,7 +96,7 @@ if node[:platform_version].to_i == 6
 	end
 
 	template "/etc/sssd/sssd.conf" do
-    sensitive true
+		senstitive true
 		source "sssd.conf.erb"
 		mode 0600
 		owner "root"

--- a/templates/default/arguments.erb
+++ b/templates/default/arguments.erb
@@ -112,7 +112,9 @@
 --smbidmapgid=<%= node[:authconfig][:winbind][:smb][:idmapgid] %>
 --winbindseparator=<%= node[:authconfig][:winbind][:separator] %>
 --winbindtemplatehomedir=<%= node[:authconfig][:winbind][:template][:homedir] %>
+<%- if node[:platform_version] < "7.3" -%>
 --winbindtemplateprimarygroup=<%= node[:authconfig][:winbind][:template][:primarygroup] %>
+<%- end -%>
 --winbindtemplateshell=<%= node[:authconfig][:winbind][:template][:shell] %>
 <% if node[:authconfig][:winbind][:usedefaultdomain] -%>
 	--enablewinbindusedefaultdomain

--- a/templates/default/arguments.erb
+++ b/templates/default/arguments.erb
@@ -28,21 +28,21 @@
 <% end -%>
 --ldapserver=<%= node[:authconfig][:ldap][:server] %>
 --ldapbasedn=<%= node[:authconfig][:ldap][:dnbase] %>
-<% if node[:authconfig][:ldap][:starttls] && node[:platform_version].to_i == 6 -%>
+<% if node[:authconfig][:ldap][:starttls] && [6, 7].include?(node[:platform_version].to_i) -%>
 	--enableldapstarttls
 <% elsif node[:authconfig][:ldap][:ssl] && node[:platform_version].to_i == 5 -%>
 	--enableldapssl
 <% elsif node[:authconfig][:ldap][:tls] -%>
 	--enableldaptls
 <% else -%>
-	<% if node[:platform_version].to_i == 6 -%>
+	<% if [6, 7].include? node[:platform_version].to_i -%>
 		--disableldapstarttls
 	<% else -%>
 		--disableldapssl
 	<% end -%>
 	--disableldaptls
 <% end -%>
-<% if node[:platform_version].to_i == 6 -%>
+<% if [6, 7].include? node[:platform_version].to_i -%>
 	<% if node[:authconfig][:ldap][:rfc2307bis] -%>
 		--enablerfc2307bis
 	<% else -%>
@@ -62,7 +62,7 @@
 <% else -%>
 	--disablesmartcard
 <% end -%>
-<% if node[:platform_version].to_i == 6 -%>
+<% if [6, 7].include? node[:platform_version].to_i -%>
 	<% if node[:authconfig][:fingerprint][:enable] -%>
 		--enablefingerprint
 	<% else -%>
@@ -144,7 +144,7 @@
 <% else -%>
 	--disablehesiod
 <% end -%>
-<% if node[:platform_version].to_i == 6 -%>
+<% if [6, 7].include? node[:platform_version].to_i -%>
 	<% if node[:authconfig][:sssd][:enable] -%>
 		--enablesssd
 	<% else -%>


### PR DESCRIPTION
With this attribute set, the clear password to access the LDAP server will not be displayed on terminal during chef-client execution event if verbose logging is enable.
